### PR TITLE
fix a lack of the paramater for DocumentDBCollection->query().

### DIFF
--- a/phpdocumentdb.php
+++ b/phpdocumentdb.php
@@ -82,7 +82,7 @@ class DocumentDBCollection
 
   public function query($query)
   {
-    return $this->document_db->query($this->rid_db, $this->rid_col);
+    return $this->document_db->query($this->rid_db, $this->rid_col, $query);
   }
 
 }


### PR DESCRIPTION
In DocumentDBCollection->query(), there is no $query param included in the function call.
So just add it.
